### PR TITLE
remove dependency to missing imghash library

### DIFF
--- a/kml_test.go
+++ b/kml_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/dustin/go-heatmap/schemes"
-	"github.com/jteeuwen/imghash"
 )
 
 const testKmlImgURL = "http://www.example.com/thing.png"
@@ -61,7 +60,7 @@ func TestKML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error generating kml: %v", err)
 	}
-	got := imghash.Average(img)
+	got := imgHash(img)
 	if got != expHash {
 		t.Errorf("Expected image hash %v, got %v", expHash, got)
 	}
@@ -153,7 +152,7 @@ func TestKMZ(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error decoding image: %v", err)
 			}
-			got := imghash.Average(img)
+			got := imgHash(img)
 			if got != expHash {
 				t.Errorf("Expected image hash %v, got %v", expHash, got)
 			}


### PR DESCRIPTION
This PR replaced the `imghash` library with `hash/fnv`.

If I run `go mod tidy` in my project I get the following error:
```
$ go mod tidy
github.com/markus-wa/demoinfocs-golang/examples/heatmap imports
    github.com/dustin/go-heatmap tested by
    github.com/dustin/go-heatmap.test imports
    github.com/jteeuwen/imghash: git ls-remote -q https://github.com/jteeuwen/imghash in C:\Users\mwalt\go\pkg\mod\cache\vcs\899a7f2d063a36fd4ddfd213140d24b9bce8d21ec528de64aa73ce33841599f9: exit status 128:
    remote: Repository not found.
    fatal: repository 'https://github.com/jteeuwen/imghash/' not found
```

`imghash` has been deleted by the owner (along with all his other repositories) a while ago, see https://github.com/jteeuwen/go-bindata/issues/5

Instead of removing the tests like #5, this PR replaces the library with a custom `imgHash()` function.